### PR TITLE
SUP-5634: Update данных в HL блоке

### DIFF
--- a/local/php_interface/init.php
+++ b/local/php_interface/init.php
@@ -282,41 +282,6 @@
 
 
     function NewItemInfo($arFields) {
-    	// актуализируем инфу для поиска, переносим инфу о новых деталях в HL блок
-		if ($arFields["IBLOCK_ID"] == 88) {
-			
-			$hlblock = HL\HighloadBlockTable::getById(1)->fetch();
-			$entity = HL\HighloadBlockTable::compileEntity($hlblock);
-			$entity_data_class = $entity->getDataClass();
-			
-			$rs = CIBlockElement::GetList(
-			   array('ID' => 'ASC'),
-			   array('IBLOCK_ID' => 88, "ID" => $arFields["ID"]),
-			   false, false,
-			   array('NAME', 'ID', 'CODE', 'SECTION_ID', 'URL', 'DETAIL_PAGE_URL', 'PROPERTY_SIZE', 'PROPERTY_SEARCH_CODE', 'PROPERTY_SEARCH_UNC', 'PROPERTY_SEARCH_WARRANTY', 'PROPERTY_UNC', 'PROPERTY_FIRM', 'PROPERTY_WARRANTY', 'PROPERTY_CROSS_NUM')
-			);
-			while ($ar = $rs->Fetch()) {
-			   // у результата добавления тип Bitrix\Main\Entity\AddResult
-			   // т.к. ссылка больше автоматически не формируется, сделаем это вручную здесь
-			   $detail_href = str_replace("#SECTION_ID#", $ar['IBLOCK_SECTION_ID'], $ar['DETAIL_PAGE_URL']);
-			   $detail_href = str_replace("#ID#", $ar['ID'], $detail_href);
-			   
-			   $result = $entity_data_class::add(array(
-			      'UF_TITLE'            => $ar['NAME'],
-			      'UF_CODE'             => $ar['PROPERTY_SEARCH_CODE_VALUE'],
-			      'UF_WARRANTY'         => $ar['PROPERTY_SEARCH_WARRANTY_VALUE'],
-			      'UF_UNC'              => $ar['PROPERTY_SEARCH_UNC_VALUE'],
-			      'UF_CODE_DISPLAY'     => $ar['CODE'],
-			      'UF_SIZE'             => $ar['PROPERTY_SIZE_VALUE'],
-			      'UF_DETAIL_URL'       => $detail_href,
-			      'UF_ORIGINAL_ID'      => $ar['ID'],
-			      'UF_WARRANTY_DISPLAY' => $ar['PROPERTY_WARRANTY_VALUE'],
-			      'UF_FIRM_DISPLAY'     => $firms[$ar['PROPERTY_FIRM_VALUE']],
-			      'UF_UNC_DISPLAY'      => $ar['PROPERTY_UNC_VALUE'],
-			      'UF_CROSS'            => $ar['PROPERTY_CROSS_NUM_VALUE']
-			   ));
-			}
-		}
         //предложение картинок
         if ($arFields["IBLOCK_ID"] == 96) {
 
@@ -377,7 +342,41 @@
             addSearchProps($arFields["ID"]);
         }
 
-
+		// актуализируем инфу для поиска, переносим инфу о новых деталях в HL блок
+		if ($arFields["IBLOCK_ID"] == 88) {
+			
+			$hlblock = HL\HighloadBlockTable::getById(1)->fetch();
+			$entity = HL\HighloadBlockTable::compileEntity($hlblock);
+			$entity_data_class = $entity->getDataClass();
+			
+			$rs = CIBlockElement::GetList(
+			   array('ID' => 'ASC'),
+			   array('IBLOCK_ID' => 88, "ID" => $arFields["ID"]),
+			   false, false,
+			   array('NAME', 'ID', 'CODE', 'SECTION_ID', 'URL', 'DETAIL_PAGE_URL', 'PROPERTY_SIZE', 'PROPERTY_SEARCH_CODE', 'PROPERTY_SEARCH_UNC', 'PROPERTY_SEARCH_WARRANTY', 'PROPERTY_UNC', 'PROPERTY_FIRM', 'PROPERTY_WARRANTY', 'PROPERTY_CROSS_NUM')
+			);
+			while ($ar = $rs->Fetch()) {
+			   // у результата добавления тип Bitrix\Main\Entity\AddResult
+			   // т.к. ссылка больше автоматически не формируется, сделаем это вручную здесь
+			   $detail_href = str_replace("#SECTION_ID#", $ar['IBLOCK_SECTION_ID'], $ar['DETAIL_PAGE_URL']);
+			   $detail_href = str_replace("#ID#", $ar['ID'], $detail_href);
+			   
+			   $result = $entity_data_class::add(array(
+			      'UF_TITLE'            => $ar['NAME'],
+			      'UF_CODE'             => $ar['PROPERTY_SEARCH_CODE_VALUE'],
+			      'UF_WARRANTY'         => $ar['PROPERTY_SEARCH_WARRANTY_VALUE'],
+			      'UF_UNC'              => $ar['PROPERTY_SEARCH_UNC_VALUE'],
+			      'UF_CODE_DISPLAY'     => $ar['CODE'],
+			      'UF_SIZE'             => $ar['PROPERTY_SIZE_VALUE'],
+			      'UF_DETAIL_URL'       => $detail_href,
+			      'UF_ORIGINAL_ID'      => $ar['ID'],
+			      'UF_WARRANTY_DISPLAY' => $ar['PROPERTY_WARRANTY_VALUE'],
+			      'UF_FIRM_DISPLAY'     => $firms[$ar['PROPERTY_FIRM_VALUE']],
+			      'UF_UNC_DISPLAY'      => $ar['PROPERTY_UNC_VALUE'],
+			      'UF_CROSS'            => $ar['PROPERTY_CROSS_NUM_VALUE']
+			   ));
+			}
+		}
     }
 
 

--- a/local/php_interface/init.php
+++ b/local/php_interface/init.php
@@ -16,6 +16,10 @@
         print_r($array);
         echo "</pre>";
     }
+	
+	define("HL_TABLE_NAME", "tbl_webgk_details");
+	define("CATALOG_IBLOCK_ID", 88);
+	define("HL_BLOCK_DETAILS_ID", 1);
 
     CModule::IncludeModule('sale');
     CModule::IncludeModule('catalog');
@@ -380,11 +384,60 @@
     }
 
 
-//дублируем свойства для поиска
+	//дублируем свойства для поиска
     function UpdateItemInfo($arFields) {
         if ($arFields["IBLOCK_ID"] == 88) {
             addSearchProps($arFields["ID"]);
         }
+		
+		// актуализируем инфу для поиска, если изменились параметры элемента, то переносим данные в HL блок
+		if ($arFields["IBLOCK_ID"] == 88) {
+			
+			$hlblock = HL\HighloadBlockTable::getById(HL_BLOCK_DETAILS_ID)->fetch();
+			$entity = HL\HighloadBlockTable::compileEntity($hlblock);
+			$entity_data_class = $entity->getDataClass();
+			
+			$rs = CIBlockElement::GetList(
+			   array('ID' => 'ASC'),
+			   array('IBLOCK_ID' => CATALOG_IBLOCK_ID, "ID" => $arFields["ID"]),
+			   false, false,
+			   array('NAME', 'ID', 'CODE', 'SECTION_ID', 'URL', 'DETAIL_PAGE_URL', 'PROPERTY_SIZE', 'PROPERTY_SEARCH_CODE', 'PROPERTY_SEARCH_UNC', 'PROPERTY_SEARCH_WARRANTY', 'PROPERTY_UNC', 'PROPERTY_FIRM', 'PROPERTY_WARRANTY', 'PROPERTY_CROSS_NUM')
+			);
+			if ($ar = $rs->Fetch()) {
+				$hl_elements_result = $entity_data_class::getList(array(
+					"select" => array('*'),
+					"filter" => array("UF_ORIGINAL_ID" => $arFields["ID"]),
+					"order"  => array(),
+					"limit"  => 1
+				));
+				$hl_elements_result = new CDBResult($hl_elements_result, HL_TABLE_NAME);
+				if ($hl_element = $hl_elements_result->Fetch()) {
+					// проверяем, изменились ли поля
+					if (
+						$hl_element['UF_CROSS'] != $ar['PROPERTY_CROSS_NUM_VALUE']
+						|| $hl_element['UF_UNC'] != $ar['PROPERTY_SEARCH_UNC_VALUE']
+						|| $hl_element['UF_WARRANTY'] != $ar['PROPERTY_SEARCH_WARRANTY_VALUE']
+						|| $hl_element['UF_CODE'] != $ar['PROPERTY_SEARCH_CODE_VALUE']
+						|| $hl_element['UF_TITLE'] != $ar['NAME']
+					) {
+						// если какие-то поля изменились, обновляем HL элемент
+						$update_result = $entity_data_class::update(
+							$hl_element['ID'],
+							array(
+						      'UF_TITLE'            => $ar['NAME'],
+						      'UF_CODE'             => $ar['PROPERTY_SEARCH_CODE_VALUE'],
+						      'UF_CODE_DISPLAY'     => $ar['CODE'],
+						      'UF_WARRANTY'         => $ar['PROPERTY_SEARCH_WARRANTY_VALUE'],
+						      'UF_WARRANTY_DISPLAY' => $ar['PROPERTY_WARRANTY_VALUE'],
+						      'UF_UNC'              => $ar['PROPERTY_SEARCH_UNC_VALUE'],
+						      'UF_UNC_DISPLAY'      => $ar['PROPERTY_UNC_VALUE'],
+						      'UF_CROSS'            => $ar['PROPERTY_CROSS_NUM_VALUE']
+						   )
+						); 
+					}
+				}
+			}
+		}
     }
 
     //Функция которая инициализирует почтовое событие при смене статуса заказа через 1с


### PR DESCRIPTION
1) Исправлена проблема с переносом данных о новых товарах в HL инфоблок. Из-за которой склеенные артикулы/OEM не переносились, так как еще не были созданы
2) Update данных в HL блоке после обновления данных в основном